### PR TITLE
Mark tests as passed/failed in Browserstack with reason

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
-# protractor-browserstack
+# protractor-browserstack with marking tests as passed/failed with reason 
+
+####The incentive behind this fork is to demonstrate how to mark tests as passed/ failed in browserstack. <br/>Browserstack's current documentation does not allow you to do so. So even if your test fails it will be marked as passed (green) on browserstack.<br/><br/>In addition, there is an example of how to update the reason for the test's failure using browserstack rest api. see 'single_failed.js'
 
 [Protractor](https://github.com/angular/protractor/) Integration with BrowserStack.
+
+Mark tests as passed/failed in Browserstack
+
+Report reason for failed test to Browserstack
+
+Report failed expectations to Browserstack
+
+Upgrade to support Protractor 5   
 
 ![BrowserStack Logo](https://d98b8t1nnulk5.cloudfront.net/production/images/layout/logo-header.png?1469004780)
 
@@ -14,6 +24,7 @@
 
 ## Running your tests
 * To run a single test, run `npm run single`
+* To run a single test that will report the reason for failed tests to browserstack, run `npm run single_failed`
 * To run local tests, run `npm run local`
 * To run parallel tests, run `npm run parallel`
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # protractor-browserstack with marking tests as passed/failed with reason 
 
-####The incentive behind this fork is to demonstrate how to mark tests as passed/ failed in browserstack. <br/>Browserstack's current documentation does not allow you to do so. So even if your test fails it will be marked as passed (green) on browserstack.<br/><br/>In addition, there is an example of how to update the reason for the test's failure using browserstack rest api. see 'single_failed.js'
+#### The incentive behind this fork is to demonstrate how to mark tests as passed/ failed in browserstack. <br/>Browserstack's current documentation does not allow you to do so. So even if your test fails it will be marked as passed (green) on browserstack.<br/><br/>In addition, there is an example of how to update the reason for the test's failure using browserstack rest api. see 'single_failed.js'
 
 [Protractor](https://github.com/angular/protractor/) Integration with BrowserStack.
 

--- a/conf/local.conf.js
+++ b/conf/local.conf.js
@@ -1,5 +1,6 @@
 var browserstack = require('browserstack-local');
-
+console.log('process.env.BROWSERSTACK_USERNAME', process.env.BROWSERSTACK_USERNAME);
+console.log('process.env.BROWSERSTACK_ACCESS_KEY', process.env.BROWSERSTACK_ACCESS_KEY);
 exports.config = {
   'specs': [ '../specs/local.js' ],
   'seleniumAddress': 'http://hub-cloud.browserstack.com/wd/hub',
@@ -19,7 +20,7 @@ exports.config = {
     console.log("Connecting local");
     return new Promise(function(resolve, reject){
       exports.bs_local = new browserstack.Local();
-      exports.bs_local.start({'key': exports.config.capabilities['browserstack.key'] }, function(error) {
+      exports.bs_local.start({'key': exports.config.capabilities['browserstack.key'], force: true}, function (error) {
         if (error) return reject(error);
         console.log('Connected. Now testing...');
 

--- a/conf/local.conf.js
+++ b/conf/local.conf.js
@@ -1,13 +1,11 @@
 var browserstack = require('browserstack-local');
-console.log('process.env.BROWSERSTACK_USERNAME', process.env.BROWSERSTACK_USERNAME);
-console.log('process.env.BROWSERSTACK_ACCESS_KEY', process.env.BROWSERSTACK_ACCESS_KEY);
 exports.config = {
   'specs': [ '../specs/local.js' ],
-  'seleniumAddress': 'http://hub-cloud.browserstack.com/wd/hub',
+
+  browserstackUser: process.env.BROWSERSTACK_USERNAME || 'BROWSERSTACK_USERNAME',
+  browserstackKey: process.env.BROWSERSTACK_ACCESS_KEY || 'BROWSERSTACK_ACCESS_KEY',
 
   'capabilities': {
-    'browserstack.user': process.env.BROWSERSTACK_USERNAME || 'BROWSERSTACK_USERNAME',
-    'browserstack.key': process.env.BROWSERSTACK_ACCESS_KEY || 'BROWSERSTACK_ACCESS_KEY',
     'build': 'protractor-browserstack',
     'name': 'local_test',
     'browserName': 'chrome',
@@ -20,7 +18,7 @@ exports.config = {
     console.log("Connecting local");
     return new Promise(function(resolve, reject){
       exports.bs_local = new browserstack.Local();
-      exports.bs_local.start({'key': exports.config.capabilities['browserstack.key'], force: true}, function (error) {
+      exports.bs_local.start({'key': exports.config.browserstackKey, force: true}, function (error) {
         if (error) return reject(error);
         console.log('Connected. Now testing...');
 

--- a/conf/local_failed.conf.js
+++ b/conf/local_failed.conf.js
@@ -1,32 +1,24 @@
 var browserstack = require('browserstack-local');
-
 exports.config = {
-  'specs': [ '../specs/local.js' ],
+  'specs': [ '../specs/local_fail.js' ],
 
   browserstackUser: process.env.BROWSERSTACK_USERNAME || 'BROWSERSTACK_USERNAME',
   browserstackKey: process.env.BROWSERSTACK_ACCESS_KEY || 'BROWSERSTACK_ACCESS_KEY',
 
-  'commonCapabilities': {
+  'capabilities': {
     'build': 'protractor-browserstack',
-    'name': 'parallel_local_test',
+    'name': 'local test reporting failed',
+    'browserName': 'chrome',
     'browserstack.local': true,
     'browserstack.debug': 'true'
   },
-
-  'multiCapabilities': [{
-    'browserName': 'Chrome'
-  },{
-    'browserName': 'Firefox'
-  },{
-    'browserName': 'Safari'
-  }],
 
   // Code to start browserstack local before start of test
   beforeLaunch: function(){
     console.log("Connecting local");
     return new Promise(function(resolve, reject){
       exports.bs_local = new browserstack.Local();
-      exports.bs_local.start({'key': exports.config.browserstackKey }, function(error) {
+      exports.bs_local.start({'key': exports.config.browserstackKey, force: true}, function (error) {
         if (error) return reject(error);
         console.log('Connected. Now testing...');
 
@@ -42,8 +34,3 @@ exports.config = {
     });
   }
 };
-
-// Code to support common capabilities
-exports.config.multiCapabilities.forEach(function(caps){
-  for(var i in exports.config.commonCapabilities) caps[i] = caps[i] || exports.config.commonCapabilities[i];
-});

--- a/conf/parallel.conf.js
+++ b/conf/parallel.conf.js
@@ -1,10 +1,10 @@
 exports.config = {
   'specs': [ '../specs/single.js' ],
-  'seleniumAddress': 'http://hub-cloud.browserstack.com/wd/hub',
+
+  browserstackUser: process.env.BROWSERSTACK_USERNAME || 'BROWSERSTACK_USERNAME',
+  browserstackKey: process.env.BROWSERSTACK_ACCESS_KEY || 'BROWSERSTACK_ACCESS_KEY',
 
   'commonCapabilities': {
-    'browserstack.user': process.env.BROWSERSTACK_USERNAME || 'BROWSERSTACK_USERNAME',
-    'browserstack.key': process.env.BROWSERSTACK_ACCESS_KEY || 'BROWSERSTACK_ACCESS_KEY',
     'build': 'protractor-browserstack',
     'name': 'parallel_test',
     'browserstack.debug': 'true',

--- a/conf/single_fail.conf.js
+++ b/conf/single_fail.conf.js
@@ -1,12 +1,12 @@
 exports.config = {
-  'specs': [ '../specs/single.js' ],
+  'specs': [ '../specs/single_fail.js' ],
 
   browserstackUser: process.env.BROWSERSTACK_USERNAME || 'BROWSERSTACK_USERNAME',
   browserstackKey: process.env.BROWSERSTACK_ACCESS_KEY || 'BROWSERSTACK_ACCESS_KEY',
 
   'capabilities': {
     'build': 'protractor-browserstack',
-    'name': 'single test',
+    'name': 'single test reporting failed',
     'browserName': 'chrome',
     'resolution': '1024x768',
     'browserstack.debug': 'true'

--- a/lib/BrowserstackErrorLogger.js
+++ b/lib/BrowserstackErrorLogger.js
@@ -1,0 +1,34 @@
+const request = require('request');
+class BrowserstackErrorLogger {
+  constructor() {
+    this.BROWSERSTACK_USERNAME = process.env.BROWSERSTACK_USERNAME || 'BROWSERSTACK_USERNAME';
+    this.BROWSERSTACK_ACCESS_KEY = process.env.BROWSERSTACK_ACCESS_KEY || 'BROWSERSTACK_ACCESS_KEY';
+    this.errors = [];
+    this.sessionId = "";
+  }
+
+  buildErrorsRrport() {
+    return JSON.stringify(this.errors);
+  }
+
+  setSessionId(sessionId) {
+    this.sessionId = sessionId;
+  }
+
+  addError(title, error) {
+    // this.errors.push({title, error});
+    this.errors.push(title);
+  }
+
+  async reportErrors() {
+    if (this.errors.length) {
+      await request({
+        uri: `https://${this.BROWSERSTACK_USERNAME}:${this.BROWSERSTACK_ACCESS_KEY}@api.browserstack.com/automate/sessions/${this.sessionId}.json`,
+        method: 'PUT',
+        form: {status: 'failed', reason: this.buildErrorsRrport()}
+      });
+    }
+  }
+}
+
+module.exports = BrowserstackErrorLogger;

--- a/lib/BrowserstackErrorReporter.js
+++ b/lib/BrowserstackErrorReporter.js
@@ -1,5 +1,5 @@
 const request = require('request');
-class BrowserstackErrorLogger {
+class BrowserstackErrorReporter {
   constructor() {
     this.BROWSERSTACK_USERNAME = process.env.BROWSERSTACK_USERNAME || 'BROWSERSTACK_USERNAME';
     this.BROWSERSTACK_ACCESS_KEY = process.env.BROWSERSTACK_ACCESS_KEY || 'BROWSERSTACK_ACCESS_KEY';
@@ -7,7 +7,7 @@ class BrowserstackErrorLogger {
     this.sessionId = "";
   }
 
-  buildErrorsRrport() {
+  buildErrorsReport() {
     return JSON.stringify(this.errors);
   }
 
@@ -25,10 +25,10 @@ class BrowserstackErrorLogger {
       await request({
         uri: `https://${this.BROWSERSTACK_USERNAME}:${this.BROWSERSTACK_ACCESS_KEY}@api.browserstack.com/automate/sessions/${this.sessionId}.json`,
         method: 'PUT',
-        form: {status: 'failed', reason: this.buildErrorsRrport()}
+        form: {status: 'failed', reason: this.buildErrorsReport()}
       });
     }
   }
 }
 
-module.exports = BrowserstackErrorLogger;
+module.exports = BrowserstackErrorReporter;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "test": "npm run single && npm run local && npm run parallel",
     "single": "./node_modules/.bin/protractor conf/single.conf.js",
+    "single_fail": "./node_modules/.bin/protractor conf/single_fail.conf.js",
     "local": "./node_modules/.bin/protractor conf/local.conf.js",
+    "local_fail": "./node_modules/.bin/protractor conf/local_fail.conf.js",
     "parallel": "./node_modules/.bin/protractor conf/parallel.conf.js",
     "parallel_local": "./node_modules/.bin/protractor conf/parallel_local.conf.js"
   },
@@ -16,7 +18,7 @@
   },
   "dependencies": {
     "browserstack-local": "^1.0.0",
-    "protractor": "^2.5.1"
+    "protractor": "^5.3.1"
   },
   "license": "MIT"
 }

--- a/specs/local.js
+++ b/specs/local.js
@@ -2,7 +2,12 @@ describe('BrowserStack Local Testing', function() {
   it('can check tunnel working', function() {
     browser.driver.get('http://bs-local.com:45691/check').then(function() {
       expect(browser.driver.getPageSource()).toMatch(/Up and running/i);
+      expect(true).toBe(false);
     });
+  });
+
+  it('should fail and report to browserstack', function() {
+    expect(true).toBe(false);
   });
 });
 

--- a/specs/local.js
+++ b/specs/local.js
@@ -2,12 +2,7 @@ describe('BrowserStack Local Testing', function() {
   it('can check tunnel working', function() {
     browser.driver.get('http://bs-local.com:45691/check').then(function() {
       expect(browser.driver.getPageSource()).toMatch(/Up and running/i);
-      expect(true).toBe(false);
     });
-  });
-
-  it('should fail and report to browserstack', function() {
-    expect(true).toBe(false);
   });
 });
 

--- a/specs/local_fail.js
+++ b/specs/local_fail.js
@@ -1,0 +1,6 @@
+describe('BrowserStack Local Testing', function() {
+  it('should fail and report to browserstack', function() {
+    expect(true).toBe(false);
+  });
+});
+

--- a/specs/single.js
+++ b/specs/single.js
@@ -6,11 +6,15 @@ describe('Google\'s Search Functionality', function() {
           browser.driver.wait(function() {
             return browser.driver.findElements(by.id('resultStats')).then(function(elems) {
               return elems.length > 0;
-            });;
+            });
           });
           expect(browser.driver.getTitle()).toEqual('BrowserStack - Google Search');
         });
       });
     });
+  });
+
+  it('should fail and report to browserstack', function() {
+    expect(true).toBe(false);
   });
 });

--- a/specs/single.js
+++ b/specs/single.js
@@ -2,7 +2,7 @@ describe('Google\'s Search Functionality', function() {
   it('can find search results', function() {
     browser.driver.get('https://google.com/ncr').then(function() {
       browser.driver.findElement(by.name('q')).sendKeys('BrowserStack').then(function() {
-        browser.driver.findElement(by.name('btnG')).click().then(function() {
+        browser.actions().sendKeys(protractor.Key.ENTER).perform().then(function() {
           browser.driver.wait(function() {
             return browser.driver.findElements(by.id('resultStats')).then(function(elems) {
               return elems.length > 0;
@@ -12,9 +12,5 @@ describe('Google\'s Search Functionality', function() {
         });
       });
     });
-  });
-
-  it('should fail and report to browserstack', function() {
-    expect(true).toBe(false);
   });
 });

--- a/specs/single_fail.js
+++ b/specs/single_fail.js
@@ -1,4 +1,4 @@
-var BrowserstackErrorLogger = require('../lib/BrowserstackErrorLogger');
+var BrowserstackErrorReporter = require('../lib/BrowserstackErrorReporter');
 
 jasmine.getEnv().addReporter({
   specStarted(result) {
@@ -11,7 +11,7 @@ jasmine.getEnv().addReporter({
 
 describe('Reporting to BrowserStack that test failed with reason', function() {
 
-  const reporter = new BrowserstackErrorLogger();
+  const reporter = new BrowserstackErrorReporter();
   beforeAll(async () => {
     await protractor.browser.driver.getSession().then((session) => {
       reporter.setSessionId(session['id_']);
@@ -21,7 +21,7 @@ describe('Reporting to BrowserStack that test failed with reason', function() {
   afterEach(function () {
     let failedExpectations = jasmine.getEnv().currentSpec.failedExpectations;
     if (failedExpectations.length) {
-      reporter.addError(failedExpectations[0].message, failedExpectations[0].stack)
+      failedExpectations.forEach(f => reporter.addError(f.message, f.stack));
     }
   });
 

--- a/specs/single_fail.js
+++ b/specs/single_fail.js
@@ -1,0 +1,5 @@
+describe('Reporting to BrowserStack that test failed', function() {
+  it('should fail and report to browserstack', function() {
+    expect(true).toBe(false);
+  });
+});

--- a/specs/single_fail.js
+++ b/specs/single_fail.js
@@ -1,5 +1,39 @@
-describe('Reporting to BrowserStack that test failed', function() {
-  it('should fail and report to browserstack', function() {
+var BrowserstackErrorLogger = require('../lib/BrowserstackErrorLogger');
+
+jasmine.getEnv().addReporter({
+  specStarted(result) {
+    jasmine.getEnv().currentSpec = result;
+  },
+  specDone() {
+    jasmine.getEnv().currentSpec = null;
+  }
+});
+
+describe('Reporting to BrowserStack that test failed with reason', function() {
+
+  const reporter = new BrowserstackErrorLogger();
+  beforeAll(async () => {
+    await protractor.browser.driver.getSession().then((session) => {
+      reporter.setSessionId(session['id_']);
+    });
+  });
+
+  afterEach(function () {
+    let failedExpectations = jasmine.getEnv().currentSpec.failedExpectations;
+    if (failedExpectations.length) {
+      reporter.addError(failedExpectations[0].message, failedExpectations[0].stack)
+    }
+  });
+
+  afterAll(async () => {
+    return reporter.reportErrors();
+  });
+
+  it('should fail and report reason to browserstack', function() {
     expect(true).toBe(false);
+  });
+
+  it('should not fail and will not be reported to browserstack', function() {
+    expect(true).toBe(true);
   });
 });


### PR DESCRIPTION
The incentive behind this fork is to demonstrate how to mark tests as passed/ failed in browserstack. 
Browserstack's current documentation does not allow you to do so. So even if your test fails it will be marked as passed (green) on browserstack.

In addition, there is an example of how to update the reason for the test's failure using browserstack rest api. see 'single_failed.js'

Mark tests as passed/failed in Browserstack

Report reason for failed test to Browserstack

Report failed expectations to Browserstack

Upgrade to support Protractor 5